### PR TITLE
set default admin token to selected default keystone password

### DIFF
--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -184,6 +184,9 @@ curl -s -L --insecure https://github.com/openstack/keystone/raw/icehouse-eol/etc
      | .cloud_service="rule:service_role and domain_id:'${ID_ADMIN_DOMAIN}'"' \
   | tee /etc/keystone/policy.json
 
+# Set another ADMIN TOKEN
+openstack-config --set /etc/keystone/keystone.conf \
+                 DEFAULT admin_token $KEYSTONE_ADMIN_PASSWORD
 
 kill -9 $keystone_all_pid
 sleep 3


### PR DESCRIPTION
IOTP keystone config just enables cloud_admin or a specific admin service to do admin operations (see policy.json), but it's possible that if you know the name of a service and that default admin token then you can use it.