### PR TITLE
added --with-release option and changed options style

### DIFF
--- a/package-keystone-spassword.sh
+++ b/package-keystone-spassword.sh
@@ -16,12 +16,14 @@ ELEMENTS=${#args[@]}
 
 for (( i=0;i<$ELEMENTS;i++)); do
     arg=${args[${i}]}
-    if [ "$arg" == "with_python27" ]; then
+    if [ "$arg" == "--with-python27" ]; then
         PYTHON27_VALUE=1
     fi
-    if [ "$arg" == "with_version" ]; then
+    if [ "$arg" == "--with-version" ]; then
         VERSION_VALUE=${args[${i}+1]}
-        RELEASE_VALUE=0
+    fi
+    if [ "$arg" == "--with-release" ]; then
+        RELEASE_VALUE=${args[${i}+1]}
     fi
 done
 


### PR DESCRIPTION
Same PR as https://github.com/telefonicaid/fiware-keystone-spassword/pull/29 against the release/1.1.0 branch 