### PR TITLE
render sndfa and email checks in html

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+Render check email and sndfa response in HTML
+
 1.4.4
 
 Add sndfa_endpoint protocol if not provided

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Render check email and sndfa response in HTML
+Render check email and sndfa response in HTML (#88)
 
 1.4.4
 

--- a/keystone_spassword/contrib/spassword/controllers.py
+++ b/keystone_spassword/contrib/spassword/controllers.py
@@ -209,9 +209,13 @@ class SPasswordV3Controller(controller.V3Controller, SendMail):
                                                                user_info['name']))
         self._check_user_has_email_validated(user_info)
         if self.spassword_api.user_check_sndfa_code(user_id, code):
-            return wsgi.render_response(status=('204', 'sndfa Authorized'))
+            # Render response in HTML
+            headers = [('Content-Type', 'text/html')]
+            return wsgi.render_response(body="Valid code. Sndfa successfully authorized",
+                                        status=('200', 'Valid code'),
+                                        headers=headers)
         else:
-            return wsgi.render_response(status=('401', 'sndfa Unauthorized'))
+            return wsgi.render_response(status=('401', 'No valid code. sndfa Unauthorized'))
 
     def ask_for_check_email_code(self, context, user_id):
         """Ask a code for user email check """
@@ -244,6 +248,10 @@ class SPasswordV3Controller(controller.V3Controller, SendMail):
         LOG.debug('check sndfa code invoked for user %s %s' % (user_info['id'],
                                                                user_info['name']))
         if self.spassword_api.user_check_email_code(user_id, code):
-            return wsgi.render_response(status=('204', 'Valid code. Email checked'))
+            # Render response in HTML
+            headers = [('Content-Type', 'text/html')]
+            return wsgi.render_response(body="Valid code. Email sucessfully checked",
+                                        status=('200', 'Valid code'),
+                                        headers=headers)
         else:
-            return wsgi.render_response(status=('401', 'No valid code.'))
+            return wsgi.render_response(status=('401', 'No valid code. Email not checked'))


### PR DESCRIPTION
fix issue: https://github.com/telefonicaid/fiware-keystone-spassword/issues/88

Currently email links for check email and sndfa codes are returning a black space. 
A minimal HTML page would be desirable.