### PR TITLE
check if http and /idm is in endpoint

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+Allow sndfa endpoints urls with `https` and `/idm`
+
 1.5.0
 
 Upgrade plugin for compatibility with Mitaka version (including docker).

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Allow sndfa endpoints urls with `https` and `/idm`
+Allow sndfa endpoints (keystone) urls with `https` and `/idm`
 
 1.5.0
 

--- a/docs/second_factor_auth.md
+++ b/docs/second_factor_auth.md
@@ -28,7 +28,7 @@ sndfa_endpoint='localhost:5001'
 
 * `sndfa` is a boolean which enables (true) or disables (false) if Second Factor Authentication feature is available in Keystone instance.
 * `sndfa_time_window` indicates the time in hours in which Second Factor Authentication performed by an user is still valid before ask another new one.
-* `sndfa_endpoint` is the endpoint used in links sent by email to users to check email address and sndfa changes
+* `sndfa_endpoint` is the endpoint used in links sent by email to users to check email address and sndfa changes (i.e. localhost:5001, https://localhost/idm, etc.)
 
 
 In order to work with Second Factor Authentication feature spassword needs a proper smtp configuration; make sure that you provide one.

--- a/keystone_spassword/contrib/spassword/backends/sql.py
+++ b/keystone_spassword/contrib/spassword/backends/sql.py
@@ -378,9 +378,9 @@ class Identity(Identity, SendMail):
                             subject = 'IoT Platform second factor auth procedure'
                             text = 'The code for verify your access is %s' % code
                             # Check if http is in endpoint
-                            link = ""
+                            link = ''
                             if not 'http' in CONF.spassword.sndfa_endpoint:
-                                link += "http://"
+                                link += 'http://'
                             # Check if /idm is in endpoint
                             if '/idm' in CONF.spassword.sndfa_endpoint:
                                 link += '%s/users/%s/sndfa/%s' % (CONF.spassword.sndfa_endpoint, user_id, code)

--- a/keystone_spassword/contrib/spassword/backends/sql.py
+++ b/keystone_spassword/contrib/spassword/backends/sql.py
@@ -377,7 +377,15 @@ class Identity(Identity, SendMail):
                             to = self.get_user(user_id)['email']
                             subject = 'IoT Platform second factor auth procedure'
                             text = 'The code for verify your access is %s' % code
-                            link = 'http://%s/v3/users/%s/sndfa/%s' % (CONF.spassword.sndfa_endpoint, user_id, code)
+                            # Check if http is in endpoint
+                            link = ""
+                            if not 'http' in CONF.spassword.sndfa_endpoint:
+                                link += "http://"
+                            # Check if /idm is in endpoint
+                            if '/idm' in CONF.spassword.sndfa_endpoint:
+                                link += '%s/users/%s/sndfa/%s' % (CONF.spassword.sndfa_endpoint, user_id, code)
+                            else:
+                                link += '%s/v3/users/%s/sndfa/%s' % (CONF.spassword.sndfa_endpoint, user_id, code)
                             text += '\nLink to verify your access is: %s' % link
                             self.send_email(to, subject, text)
                             res = None


### PR DESCRIPTION
Allow all kind of endpoint urls (including https and portal shortpaths)