### PR TITLE
remove warning about deprecated import

### DIFF
--- a/docker/core_auth.patch
+++ b/docker/core_auth.patch
@@ -29,7 +29,7 @@
 +        'favor of its entrypoint from %(namespace)r and may be removed in '
 +        'N.') %
 +        {'name': plugin_name, 'namespace': namespace})
-+    versionutils.report_deprecated_feature(LOG, msg)
++    #versionutils.report_deprecated_feature(LOG, msg)
 +
 +    return driver
  

--- a/docker/manager.patch
+++ b/docker/manager.patch
@@ -26,7 +26,7 @@
 +        'favor of its entrypoint from %(namespace)r and may be removed in '
 +        'N.') %
 +        {'name': driver_name, 'namespace': namespace})
-+    versionutils.report_deprecated_feature(LOG, msg)
++    #versionutils.report_deprecated_feature(LOG, msg)
 +
 +    return driver
  


### PR DESCRIPTION
Avoid this kind of warnings:

```
020-09-23 11:02:21.111 38 WARNING keystone.common.manager [-] Deprecated: Direct import of driver 'keystone_spassword.contrib.spassword.backends.sql.SPassword' is deprecated as of Liberty in favor of its entrypoint from 'keystone.contrib.spassword' and may be removed in N.: NoMatches: No 'keystone.contrib.spassword' driver found, looking for 'keystone_spassword.contrib.spassword.backends.sql.SPassword'
2020-09-23 11:02:21.122 38 WARNING stevedore.named [-] Could not load keystone_spassword.contrib.spassword.SPassword
2020-09-23 11:02:21.123 38 WARNING keystone.auth.core [-] Deprecated: Direct import of driver 'keystone_spassword.contrib.spassword.SPassword' is deprecated as of Liberty in favor of its entrypoint from 'keystone.auth.password' and may be removed in N.: NoMatches: No 'keystone.auth.password' driver found, looking for 'keystone_spassword.contrib.spassword.SPassword'
2020-09-23 12:51:13.043 33 WARNING keystone.access_rules_config.backends.json [-] No config file found for access rules, application credential access rules will be unavailable.: IOError: [Errno 2] No such file or directory: '/etc/keystone/access_rules.json'
2020-09-23 12:51:13.276 33 WARNING stevedore.named [-] Could not load keystone_spassword.contrib.spassword.backends.sql.Identity
2020-09-23 12:51:13.380 33 WARNING keystone.common.manager [-] Deprecated: Direct import of driver 'keystone_spassword.contrib.spassword.backends.sql.Identity' is deprecated as of Liberty in favor of its entrypoint from 'keystone.identity' and may be removed in N.: NoMatches: No 'keystone.identity' driver found, looking for 'keystone_spassword.contrib.spassword.backends.sql.Identity'
2020-09-23 12:51:13.534 33 WARNING stevedore.named [-] Could not load keystone_spassword.contrib.spassword.backends.sql.SPassword
2020-09-23 12:51:13.535 33 WARNING keystone.common.manager [-] Deprecated: Direct import of driver 'keystone_spassword.contrib.spassword.backends.sql.SPassword' is deprecated as of Liberty in favor of its entrypoint from 'keystone.contrib.spassword' and may be removed in N.: NoMatches: No 'keystone.contrib.spassword' driver found, looking for 'keystone_spassword.contrib.spassword.backends.sql.SPassword'
```