### PR TITLE
ensure fernet-keys folder permissions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+Add env var to enable/disable fernet token rotation
 Upgrade Dockerfile base image from centos7.7.1908 to centos7.9.2009
 
 1.11.0

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ To achieve that there are two options:
 - Distribute fernet keys folder content with a `rsync` command abroad all keystone nodes
 - Ensure keystone Load Balancer is using sticky sessions (example for ha proxy)[https://thisinterestsme.com/haproxy-sticky-sessions/]
 
-For non production environments there is another option: disable fernet keys rotation.
+For non production environments there is another option: disable fernet keys rotation by setting env var: `ROTATE_FERNET_KEYS=False`
 
 ## Hacking
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,21 @@ installed), the RPM package can be built invoking the following command:
 sh ./package-keystone-spassword.sh
 ```
 
+## Fernet keys and HA
+
+Since version 1.10 keystone-spassword is based on Keystone Stein and therefore uses Fernet keys. Full detail about these token could be found at [this faq](https://docs.openstack.org/keystone/stein/admin/fernet-token-faq.html).
+
+Sumarizing the implications for HA enviroment we can say:
+- Fernet keys are stored in /etc/keystone/fernet-keys folder
+- Fernet keys should periodically rotated
+- Fernet keys should be the same for all nodes of an HA environment.
+
+To achieve that there are two options:
+- Distribute fernet keys folder content with a `rsync` command abroad all keystone nodes
+- Ensure keystone Load Balancer is using sticky sessions (example for ha proxy)[https://thisinterestsme.com/haproxy-sticky-sessions/]
+
+For non production environments there is another option: disable fernet keys rotation.
+
 ## Hacking
 
 Local development (by default using `sqlite`). Running a local development

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,8 +134,8 @@ RUN \
     patch -f -p0 < /opt/keystone/api_auth.patch && \
     find /usr/lib/python2.7/site-packages/keystone -name "*.pyc" -delete && \
     find /usr/lib/python2.7/site-packages/keystone -name "*.pyo" -delete && \
-    # Cron task to rotate fernet tokens once a day
-    echo "0 1 * * * root /usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone" >/etc/cron.d/fernetrotate && \
+    # # Cron task to rotate fernet tokens once a day
+    # echo "0 1 * * * root /usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone" >/etc/cron.d/fernetrotate && \
     # Cleaning unused files...
     rpm -e --nodeps redhat-logos || true && yum -y erase libss && \
     yum clean all && rm -rf /var/lib/yum/yumdb && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -134,8 +134,6 @@ RUN \
     patch -f -p0 < /opt/keystone/api_auth.patch && \
     find /usr/lib/python2.7/site-packages/keystone -name "*.pyc" -delete && \
     find /usr/lib/python2.7/site-packages/keystone -name "*.pyo" -delete && \
-    # # Cron task to rotate fernet tokens once a day
-    # echo "0 1 * * * root /usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone" >/etc/cron.d/fernetrotate && \
     # Cleaning unused files...
     rpm -e --nodeps redhat-logos || true && yum -y erase libss && \
     yum clean all && rm -rf /var/lib/yum/yumdb && \

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -44,7 +44,7 @@ fi
 [[ "${SPASSWORD_SNDFA_TIME_WINDOW}" == "" ]] && export SPASSWORD_SNDFA_TIME_WINDOW=24
 
 [[ "${LOG_LEVEL}" == "" ]] && export LOG_LEVEL=WARN
-
+[[ "${ROTATE_FERNET_KEYS}" == "" ]] && export ROTATE_FERNET_KEYS=True
 
 if [ "$DB_HOST_ARG" == "-dbhost" ]; then
     openstack-config --set /etc/keystone/keystone.conf \
@@ -105,6 +105,12 @@ if [ "${LOG_LEVEL}" == "DEBUG" ]; then
     openstack-config --set /etc/keystone/keystone.conf \
     wsgi debug_middleware True
 fi
+
+if [ "${ROTATE_FERNET_KEYS}" == "True" ]; then
+    # Cron task to rotate fernet tokens once a day
+    echo "0 1 * * * root /usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone" >/etc/cron.d/fernetrotate
+fi
+
 
 echo "[ postlaunchconfig - db_sync ] "
 /usr/bin/keystone-manage db_sync

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -110,6 +110,9 @@ echo "[ postlaunchconfig - db_sync ] "
 /usr/bin/keystone-manage db_sync
 
 echo "[ postlaunchconfig - fernet_setup ] "
+# Ensure directory /etc/keystone/fernet-keys to be configured as volume
+chown -R keystone:keystone /etc/keystone/fernet-keys
+chmod -R o-rwx /etc/keystone/fernet-keys
 /usr/bin/keystone-manage fernet_setup --keystone-user keystone --keystone-group keystone
 
 echo "[ postlaunchconfig - bootstrap ] "

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -143,6 +143,12 @@ cat /opt/keystone/policy.v3cloudsample.json \
 echo "[ postlaunchconfig_update - db_sync ] "
 /usr/bin/keystone-manage db_sync
 
+# Ensure directory /etc/keystone/fernet-keys to be configured as volume
+echo "[ postlaunchconfig_update - fernet_setup ] "
+chown -R keystone:keystone /etc/keystone/fernet-keys
+chmod -R o-rwx /etc/keystone/fernet-keys
+/usr/bin/keystone-manage fernet_setup --keystone-user keystone --keystone-group keystone
+
 # Set another ADMIN TOKEN
 openstack-config --set /etc/keystone/keystone.conf \
                  DEFAULT admin_token $KEYSTONE_ADMIN_PASSWORD

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -18,4 +18,6 @@ The following environment variables are available for keystone-spassword docker
 | TOKEN_EXPIRATION_TIME       | token expiration            | 10800                   |
 | REVOKE_EXPIRATION_BUFFER    | revoke expiration_buffer    | 1800                    |
 | REDIS_ENDPOINT              | cache backend_argument      | N/A                     |
+| LOG_LEVEL                   | n/a                         | INFO                    |
+| ROTATE_FERNET_KEYS          | n/a                         | True                    |
 


### PR DESCRIPTION
Just for case of docker is using a volume for store fernet-keys (to enable distribute fernet keys abroad keystone nodes)

```
iot-keystone:
  container_name: iot-keystone
  hostname: iot-keystone
  image: telefonicaiot/fiware-keystone-spassword:latest
  links:
    - iot-mysql
  ports:
    - "5001:5001"
  environment:
    - LOG_LEVEL=DEBUG
  volumes:
    - ${PATH_LOG}/keystone:/var/log/keystone
    - ${PATH_KEYSTONE_KEYS)/keystone-keys:/etc/keystone/fernet-keys
  command: -dbhost iot-mysql -default_pwd ch4ng3!ME -mysql_pwd iotonpremise
  log_driver: json-file
  log_opt:
    max-size: "250m"
```