### PR TITLE
Update Dockerfile to disable some redundant log messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Remove some reduntant logs (flask, stevedore, oslo_policy)
+Remove some reduntant logs (flask, stevedore, oslo_policy) docker container
 
 1.12.0
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+Remove some reduntant logs (flask, stevedore, oslo_policy)
+
 1.12.0
 
 Add env var to enable/disable fernet token rotation (#163)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN \
     database connection mysql+pymysql://keystone:keystone@$DB_HOST/keystone && \
     # Set log configuration
     openstack-config --set /etc/keystone/keystone.conf \
-    DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=WARN,oslo.messaging=WARN,oslo_messaging=WARN,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=WARN,oslo_policy=ERROR,dogpile.core.dogpile=WARN && \
+    DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo.policy=ERROR,oslo_policy=ERROR,dogpile.core.dogpile=INFO,keystone.server.flask.application=ERROR && \
     mkdir -p /etc/keystone/policy.d && \
     chown keystone.keystone /etc/keystone/policy.d && \
     # Set keystone Fernet tokens

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN \
     database connection mysql+pymysql://keystone:keystone@$DB_HOST/keystone && \
     # Set log configuration
     openstack-config --set /etc/keystone/keystone.conf \
-    DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo_policy=ERROR,dogpile.core.dogpile=INFO && \
+    DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=WARN,oslo.messaging=WARN,oslo_messaging=WARN,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=WARN,oslo_policy=ERROR,dogpile.core.dogpile=WARN && \
     mkdir -p /etc/keystone/policy.d && \
     chown keystone.keystone /etc/keystone/policy.d && \
     # Set keystone Fernet tokens


### PR DESCRIPTION

Default log levels for stein:
https://docs.openstack.org/keystone/stein/configuration/samples/keystone-conf.html


#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo_policy=INFO,dogpile.core.dogpile=INFO


we need to include at least: 
```keystone.server.flask.application=ERROR```

