### PR TITLE
Task/saml2 conf for idp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,4 @@
+ADD: preconfig docker and new vars and doc to configure keystone as SAML IdP
 ADD: SPASSWORD_EXTRA_BLACKLIST env var to add extra users to `pwd_user_blacklist` for docker
 ADD: Docker healthcheck for keystone API
 Fix missed deps (python2-qpid-proton, qpid-proton-c) using epel version 7-14 (#191)

--- a/README.md
+++ b/README.md
@@ -267,4 +267,6 @@ PYTHONPATH=.:$PYTHONPATH keystone-all --config-dir etc
 
 ## [Second Factor Authentication](docs/second_factor_auth.md)
 
+## [Federation as IDP integration](docs/iotp_saml_idp.md)
+
 ## [Docker env vars](docs/DOCKER.md)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,7 +106,6 @@ RUN \
     identity domain_config_dir /etc/keystone/domains && \
     # Federation by SAML2 pre-support
     yum install xmlsec1 && \
-    openstack-config --set /etc/keystone/keystone.conf saml idp_metadata_path /etc/keystone/saml2_idp_metadata.xml && \
     # Patching ...
     ln -s /usr/lib/python2.7/site-packages/keystone/contrib/scim/scim.py  /usr/lib/python2.7/site-packages/keystone/api && \
     ln -s /usr/lib/python2.7/site-packages/keystone/contrib/spassword/spassword.py  /usr/lib/python2.7/site-packages/keystone/api && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,7 +105,7 @@ RUN \
     openstack-config --set /etc/keystone/keystone.conf \
     identity domain_config_dir /etc/keystone/domains && \
     # Federation by SAML2 pre-support
-    yum install xmlsec1 && \
+    yum install -y xmlsec1 && \
     # Patching ...
     ln -s /usr/lib/python2.7/site-packages/keystone/contrib/scim/scim.py  /usr/lib/python2.7/site-packages/keystone/api && \
     ln -s /usr/lib/python2.7/site-packages/keystone/contrib/spassword/spassword.py  /usr/lib/python2.7/site-packages/keystone/api && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,6 +104,9 @@ RUN \
     identity domain_specific_drivers_enabled true && \
     openstack-config --set /etc/keystone/keystone.conf \
     identity domain_config_dir /etc/keystone/domains && \
+    # Federation by SAML2 pre-support
+    yum install xmlsec1 && \
+    openstack-config --set /etc/keystone/keystone.conf saml idp_metadata_path /etc/keystone/saml2_idp_metadata.xml && \
     # Patching ...
     ln -s /usr/lib/python2.7/site-packages/keystone/contrib/scim/scim.py  /usr/lib/python2.7/site-packages/keystone/api && \
     ln -s /usr/lib/python2.7/site-packages/keystone/contrib/spassword/spassword.py  /usr/lib/python2.7/site-packages/keystone/api && \

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -115,7 +115,7 @@ if [ "${SAML_ENDPOINT}" != "" ]; then
     openstack-config --set /etc/keystone/keystone.conf \
                      saml idp_entity_id https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
     openstack-config --set /etc/keystone/keystone.conf \
-                     saml idp_sso_endpoint https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+                     saml idp_sso_endpoint https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/sso
 fi
 if [ "${SAML_CERTFILE}" != "" ]; then
     openstack-config --set /etc/keystone/keystone.conf \

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -111,6 +111,22 @@ if [ "${ROTATE_FERNET_KEYS}" == "True" ]; then
     echo "0 1 * * * root /usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone" >/etc/cron.d/fernetrotate
 fi
 
+if [ "${SAML_ENDPOINT}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml idp_entity_id https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml idp_sso_endpoint https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+fi
+if [ "${SAML_CERTFILE}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml certfile $SAML_CERTFILE
+fi
+if [ "${SAML_KEYFILE}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml keyfile $SAML_KEYFILE
+fi
+
+
 
 echo "[ postlaunchconfig - db_sync ] "
 /usr/bin/keystone-manage db_sync
@@ -364,6 +380,11 @@ openstack-config --set /etc/keystone/keystone.conf \
                  spassword sndfa_endpoint $SPASSWORD_SNDFA_ENDPOINT
 openstack-config --set /etc/keystone/keystone.conf \
                  spassword sndfa_time_window $SPASSWORD_SNDFA_TIME_WINDOW
+
+# Create metadata for your keystone IdP
+if [ "${SAML_ENDPOINT}" != "" && "${SAML_CERTFILE}" != "" && "${SAML_KEYFILE}" != "" ]; then
+    /usr/bin/keystone-manage saml_idp_metadata > /etc/keystone/saml2_idp_metadata.xml
+fi
 
 echo "[ postlaunchconfig ] - keystone_all_pid: " + $keystone_all_pid
 echo "[ postlaunchconfig ] - keystone_admin_pid: " + $keystone_admin_pid

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -382,7 +382,7 @@ openstack-config --set /etc/keystone/keystone.conf \
                  spassword sndfa_time_window $SPASSWORD_SNDFA_TIME_WINDOW
 
 # Create metadata for your keystone IdP
-if [ "${SAML_ENDPOINT}" != "" && "${SAML_CERTFILE}" != "" && "${SAML_KEYFILE}" != "" ]; then
+if [ "${SAML_ENDPOINT}" != "" ] && [ "${SAML_CERTFILE}" != "" ] && [ "${SAML_KEYFILE}" != "" ]; then
     /usr/bin/keystone-manage saml_idp_metadata > /etc/keystone/saml2_idp_metadata.xml
 fi
 

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -383,6 +383,7 @@ openstack-config --set /etc/keystone/keystone.conf \
 
 # Create metadata for your keystone IdP
 if [ "${SAML_ENDPOINT}" != "" ] && [ "${SAML_CERTFILE}" != "" ] && [ "${SAML_KEYFILE}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf saml idp_metadata_path /etc/keystone/saml2_idp_metadata.xml
     /usr/bin/keystone-manage saml_idp_metadata > /etc/keystone/saml2_idp_metadata.xml
 fi
 

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -98,6 +98,21 @@ if [ "${ROTATE_FERNET_KEYS}" == "True" ]; then
     echo "0 1 * * * root /usr/bin/keystone-manage fernet_rotate --keystone-user keystone --keystone-group keystone" >/etc/cron.d/fernetrotate
 fi
 
+if [ "${SAML_ENDPOINT}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml idp_entity_id https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml idp_sso_endpoint https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+fi
+if [ "${SAML_CERTFILE}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml certfile $SAML_CERTFILE
+fi
+if [ "${SAML_KEYFILE}" != "" ]; then
+    openstack-config --set /etc/keystone/keystone.conf \
+                     saml keyfile $SAML_KEYFILE
+fi
+
 
 export KEYSTONE_HOST="127.0.0.1:5001"
 
@@ -155,6 +170,12 @@ echo "[ postlaunchconfig_update - fernet_setup ] "
 chown -R keystone:keystone /etc/keystone/fernet-keys
 chmod -R o-rwx /etc/keystone/fernet-keys
 /usr/bin/keystone-manage fernet_setup --keystone-user keystone --keystone-group keystone
+
+# Create metadata for your keystone IdP
+if [ "${SAML_ENDPOINT}" != "" && "${SAML_CERTFILE}" != "" && "${SAML_KEYFILE}" != "" ]; then
+    echo "[ postlaunchconfig_update - sml2_idp_metadata ] "
+    /usr/bin/keystone-manage saml_idp_metadata > /etc/keystone/saml2_idp_metadata.xml
+fi
 
 # Set another ADMIN TOKEN
 openstack-config --set /etc/keystone/keystone.conf \

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -102,7 +102,7 @@ if [ "${SAML_ENDPOINT}" != "" ]; then
     openstack-config --set /etc/keystone/keystone.conf \
                      saml idp_entity_id https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
     openstack-config --set /etc/keystone/keystone.conf \
-                     saml idp_sso_endpoint https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+                     saml idp_sso_endpoint https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/sso
 fi
 if [ "${SAML_CERTFILE}" != "" ]; then
     openstack-config --set /etc/keystone/keystone.conf \

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -174,6 +174,7 @@ chmod -R o-rwx /etc/keystone/fernet-keys
 # Create metadata for your keystone IdP
 if [ "${SAML_ENDPOINT}" != "" ] && [ "${SAML_CERTFILE}" != "" ] && [ "${SAML_KEYFILE}" != "" ]; then
     echo "[ postlaunchconfig_update - sml2_idp_metadata ] "
+    openstack-config --set /etc/keystone/keystone.conf saml idp_metadata_path /etc/keystone/saml2_idp_metadata.xml
     /usr/bin/keystone-manage saml_idp_metadata > /etc/keystone/saml2_idp_metadata.xml
 fi
 

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -172,7 +172,7 @@ chmod -R o-rwx /etc/keystone/fernet-keys
 /usr/bin/keystone-manage fernet_setup --keystone-user keystone --keystone-group keystone
 
 # Create metadata for your keystone IdP
-if [ "${SAML_ENDPOINT}" != "" && "${SAML_CERTFILE}" != "" && "${SAML_KEYFILE}" != "" ]; then
+if [ "${SAML_ENDPOINT}" != "" ] && [ "${SAML_CERTFILE}" != "" ] && [ "${SAML_KEYFILE}" != "" ]; then
     echo "[ postlaunchconfig_update - sml2_idp_metadata ] "
     /usr/bin/keystone-manage saml_idp_metadata > /etc/keystone/saml2_idp_metadata.xml
 fi

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -20,4 +20,7 @@ The following environment variables are available for keystone-spassword docker
 | REDIS_ENDPOINT              | cache backend_argument      | N/A                     |
 | LOG_LEVEL                   | n/a                         | INFO                    |
 | ROTATE_FERNET_KEYS          | n/a                         | True                    |
+| SAML_ENDPOINT               | Keystone Endpoint used to expose SAML API for idp and sso options  | N/A            |
+| SAML_CERTFILE               | File location for SSL signing certificate (certfile)    | N/A            |
+| SAML_KEYFILE                | File location for SSL signing key (keyfile)             | N/A            |
 

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -33,7 +33,23 @@ This env var will be expanden in /etc/keystone keystone.conf
 keyfile=/etc/keystone/ssl/private/signing_key.pem
 ```
 
-And then a Service Providers must be created and registered in IdP Keystone:
+And then a Service Provider must be created and registered into IdP Keystone.
+To achive that get into container and set following env vars:
+
+```
+export KEYSTONE_HOST="127.0.0.1:5001"
+export OS_USERNAME=admin
+export OS_PROJECT_NAME=admin
+export OS_USER_DOMAIN_ID=default
+export OS_USER_DOMAIN_NAME=Default
+export OS_PROJECT_DOMAIN_ID=default
+export OS_PROJECT_DOMAIN_NAME=Default
+export OS_AUTH_URL=http://127.0.0.1:5001/v3
+export OS_IDENTITY_API_VERSION=3
+export OS_PASSWORD='<password>'
+```
+
+and then execute the followign command with proper urls:
 
 ```
 $ openstack service provider create anothersp \

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -26,7 +26,7 @@ certfile=/etc/keystone/ssl/certs/signing_cert.pem
 ```
 
 - SAML_KEYFILE
-This env var will be expanden in /etc/keystone keystone.conf
+This env var will be expanded in /etc/keystone/keystone.conf
 
 ```
 [saml]

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -49,7 +49,7 @@ export OS_IDENTITY_API_VERSION=3
 export OS_PASSWORD='<password>'
 ```
 
-and then execute the followign command with proper urls:
+and then execute the following command with proper urls:
 
 ```
 $ openstack service provider create anothersp \

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -9,7 +9,7 @@ Based on [Keystone as an Identity Provider](https://docs.openstack.org/keystone/
 These new DOCKER options should be used:
 
 - SAML_ENDPOINT
-This env var will be expanden in /etc/keystone keystone.conf
+This env var will be expanded in /etc/keystone/keystone.conf
 
 ```
 [saml]

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -1,0 +1,33 @@
+# Configure Keystone to enable SAML2 to act as IDP
+
+One of the configuration models supported by Keystone for federated identity is  Keystone as Identity Provider (IdP).
+
+
+## Configuration
+Based on [Keystone as an Identity Provider](https://docs.openstack.org/keystone/stein/admin/federation/configure_federation.html#keystone-as-idp)
+
+These new DOCKER options should be used:
+
+- SAML_ENDPOINT
+This env var will be expanden in /etc/keystone keystone.conf
+
+`
+[saml]
+idp_entity_id=https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
+idp_sso_endpoint=https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/sso
+`
+
+- SAML_CERTFILE
+This env var will be expanden in /etc/keystone keystone.conf
+
+`
+[saml]
+certfile=/etc/keystone/ssl/certs/signing_cert.pem
+`
+
+- SAML_KEYFILE
+This env var will be expanden in /etc/keystone keystone.conf
+`
+[saml]
+keyfile=/etc/keystone/ssl/private/signing_key.pem
+`

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -27,6 +27,7 @@ certfile=/etc/keystone/ssl/certs/signing_cert.pem
 
 - SAML_KEYFILE
 This env var will be expanden in /etc/keystone keystone.conf
+
 `
 [saml]
 keyfile=/etc/keystone/ssl/private/signing_key.pem

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -18,7 +18,7 @@ idp_sso_endpoint=https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/sso
 ```
 
 - SAML_CERTFILE
-This env var will be expanden in /etc/keystone keystone.conf
+This env var will be expanded in /etc/keystone/keystone.conf
 
 ```
 [saml]

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -11,24 +11,24 @@ These new DOCKER options should be used:
 - SAML_ENDPOINT
 This env var will be expanden in /etc/keystone keystone.conf
 
-`
+```
 [saml]
 idp_entity_id=https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/idp
 idp_sso_endpoint=https://$SAML_ENDPOINT/v3/OS-FEDERATION/saml2/sso
-`
+```
 
 - SAML_CERTFILE
 This env var will be expanden in /etc/keystone keystone.conf
 
-`
+```
 [saml]
 certfile=/etc/keystone/ssl/certs/signing_cert.pem
-`
+```
 
 - SAML_KEYFILE
 This env var will be expanden in /etc/keystone keystone.conf
 
-`
+```
 [saml]
 keyfile=/etc/keystone/ssl/private/signing_key.pem
-`
+```

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -34,7 +34,7 @@ keyfile=/etc/keystone/ssl/private/signing_key.pem
 ```
 
 And then a Service Provider must be created and registered into IdP Keystone.
-To achive that get into container and set following env vars:
+To achive that, get into container and set following env vars:
 
 ```
 export KEYSTONE_HOST="127.0.0.1:5001"

--- a/docs/iotp_saml_idp.md
+++ b/docs/iotp_saml_idp.md
@@ -32,3 +32,11 @@ This env var will be expanden in /etc/keystone keystone.conf
 [saml]
 keyfile=/etc/keystone/ssl/private/signing_key.pem
 ```
+
+And then a Service Providers must be created and registered in IdP Keystone:
+
+```
+$ openstack service provider create anothersp \
+--service-provider-url https://anothersp.org/Shibboleth.sso/SAML2/ECP
+--auth-url https://keystone.idp.org/v3/OS-FEDERATION/identity_providers/keystoneidp/protocols/saml2/auth
+```


### PR DESCRIPTION
Doc:
https://github.com/telefonicaid/fiware-keystone-spassword/blob/task/saml2_conf_for_idp/docs/iotp_saml_idp.md

New docker tag version: 1.12.0_saml2
https://hub.docker.com/layers/telefonicaiot/fiware-keystone-spassword/1.12.0_saml2/images/sha256-226d8c4349c62d14c2cf821a1a22f9a1b6b519f8e7a2be6d81f38fbbfa56a46b?context=repo


This is how use new env vars for docker-compose:
```
    - SAML_ENDPOINT=localhost:5001
    - SAML_CERTFILE=/etc/keystone/ssl/server.crt
    - SAML_KEYFILE=/etc/keystone/ssl/server.key
  volumes:
    - /home/iotp/server.crt:/etc/keystone/ssl/server.crt
    - /home/iotp/server.key:/etc/keystone/ssl/server.key
````