### PR TITLE
allow use postgreSQL instead of MySQL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+ADD: allow to use PostgreSQL based DB instead of MySQL based DB (#256)
+
 1.20.0
 
 ADD: allow to add and remove just one user to expiration password black list (#251)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,7 @@ RUN \
     openstack-config --set /etc/keystone/keystone.conf \
     os_inherit enabled true  && \
     openstack-config --set /etc/keystone/keystone.conf \
+    database connection mysql+pymysql://keystone:keystone@$DB_HOST/keystone && \
     # Set log configuration
     openstack-config --set /etc/keystone/keystone.conf \
     DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo.policy=ERROR,oslo_policy=ERROR,dogpile.core.dogpile=INFO,keystone.server.flask.application=ERROR && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,8 +67,6 @@ RUN \
     openstack-config --set /etc/keystone/keystone.conf \
     os_inherit enabled true  && \
     openstack-config --set /etc/keystone/keystone.conf \
-    #database connection mysql+pymysql://keystone:keystone@$DB_HOST/keystone && \
-    database connection postgresql://keystone:keystone@$DB_HOST/keystone && \
     # Set log configuration
     openstack-config --set /etc/keystone/keystone.conf \
     DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo.policy=ERROR,oslo_policy=ERROR,dogpile.core.dogpile=INFO,keystone.server.flask.application=ERROR && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN \
     # Install MySQL client
     yum -y install mysql git && \
     # Install PostgreSQL client
-    yum -y install python3-psycopg2 git && \
+    yum -y install postgresql python3-psycopg2 && \
     # Install keystone dependencies
     yum -y install rpm-build tar findutils procps-ng chkconfig && \
     yum -y install python3 cronie && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,8 @@ RUN \
     yum install -y epel-release && yum update -y epel-release && \
     # Install MySQL client
     yum -y install mysql git && \
+    # Install PostgreSQL client
+    yum -y install python3-psycopg2 git && \
     # Install keystone dependencies
     yum -y install rpm-build tar findutils procps-ng chkconfig && \
     yum -y install python3 cronie && \
@@ -65,7 +67,8 @@ RUN \
     openstack-config --set /etc/keystone/keystone.conf \
     os_inherit enabled true  && \
     openstack-config --set /etc/keystone/keystone.conf \
-    database connection mysql+pymysql://keystone:keystone@$DB_HOST/keystone && \
+    #database connection mysql+pymysql://keystone:keystone@$DB_HOST/keystone && \
+    database connection postgresql://keystone:keystone@$DB_HOST/keystone && \
     # Set log configuration
     openstack-config --set /etc/keystone/keystone.conf \
     DEFAULT default_log_levels amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=ERROR,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,oslo.policy=ERROR,oslo_policy=ERROR,dogpile.core.dogpile=INFO,keystone.server.flask.application=ERROR && \

--- a/docker/keystone-entrypoint.sh
+++ b/docker/keystone-entrypoint.sh
@@ -23,37 +23,39 @@ TOKEN_EXPIRATION_TIME_VALUE=${8}
 [[ "${TOKEN_EXPIRATION_TIME_VALUE}" == "" ]] && TOKEN_EXPIRATION_TIME_VALUE=10800  # 3 x 3600 seconds
 
 if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
+    DB_HOST_PORT=3306
     DB_READY="mysqladmin ping -s --connect-timeout=3 -h $DB_HOST_NAME -P $DB_HOST_PORT"
     DB_LIST="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'show databases'"
     DB_USE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone'"
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
-    READY="pg_isready -h $DB_HOST_NAME -p $DB_HOST_PORT -t 3"
-    DB_LIST="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U root -c '\l'"
-    DB_USE="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U root -d keystone -c 'SELECT 1'"
+    DB_HOST_PORT=5432
+    DB_READY="pg_isready -h $DB_HOST_NAME -p $DB_HOST_PORT -t 3"
+    DB_LIST="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U postgres -c '\l'"
+    DB_USE="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U postgres -d keystone -c 'SELECT 1'"
 fi
 
 if [ "$DB_HOST_ARG" == "-dbhost" ]; then
     # Wait until DB is up, even if DB is behind a load balancer
-    while ! eval $DB_READY; do sleep 10; done
+    while ! eval "$DB_READY"; do sleep 10; done
     # Check if postlaunchconfig was executed
     chkconfig openstack-keystone --level 3
     if [ "$?" == "1" ]; then
         # Check if credentials are OK
-        eval $DB_LIST
+        eval "$DB_LIST"
         if [ "$?" == "1" ]; then
-            echo "[ keystone-entrypoint - error in mysql credentials ] Keystone docker will be not configured"
+            echo "[ keystone-entrypoint - error in db credentials ] Keystone docker will be not configured"
             exit 1
         fi
         # Check if previos DB data exists
-        eval $DB_USE
-        if [ "$?" == "1" ]; then
-            rm -f /var/log/keystone/keystone.log
-            /opt/keystone/postlaunchconfig.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $DB_PASSWORD_ARG $DB_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
-        else
+        eval "$DB_USE"
+        if [ "$?" == "0" ]; then
             rm -f /var/log/keystone/keystone.log
             /opt/keystone/postlaunchconfig_update.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $DB_PASSWORD_ARG $DB_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
+        else
+            rm -f /var/log/keystone/keystone.log
+            /opt/keystone/postlaunchconfig.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $DB_PASSWORD_ARG $DB_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
         fi
     fi
 fi

--- a/docker/keystone-entrypoint.sh
+++ b/docker/keystone-entrypoint.sh
@@ -23,14 +23,12 @@ TOKEN_EXPIRATION_TIME_VALUE=${8}
 [[ "${TOKEN_EXPIRATION_TIME_VALUE}" == "" ]] && TOKEN_EXPIRATION_TIME_VALUE=10800  # 3 x 3600 seconds
 
 if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
-    DB_TYPE=mysql
     DB_READY="mysqladmin ping -s --connect-timeout=3 -h $DB_HOST_NAME -P $DB_HOST_PORT"
     DB_LIST="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'show databases'"
     DB_USE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone'"
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
-    DB_TYPE=psql
     READY="pg_isready -h $DB_HOST_NAME -p $DB_HOST_PORT -t 3"
     DB_LIST="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U root -c '\l'"
     DB_USE="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U root -d keystone -c 'SELECT 1'"

--- a/docker/keystone-entrypoint.sh
+++ b/docker/keystone-entrypoint.sh
@@ -13,8 +13,8 @@ DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
 
-MYSQL_PASSWORD_ARG=${5}
-MYSQL_PASSWORD_VALUE=${6}
+DB_PASSWORD_ARG=${5}
+DB_PASSWORD_VALUE=${6}
 
 TOKEN_EXPIRATION_TIME_ARG=${7}
 TOKEN_EXPIRATION_TIME_VALUE=${8}
@@ -22,26 +22,40 @@ TOKEN_EXPIRATION_TIME_VALUE=${8}
 [[ "${TOKEN_EXPIRATION_TIME_ARG}" == "" ]] && TOKEN_EXPIRATION_TIME_ARG="-token_expiration_time"
 [[ "${TOKEN_EXPIRATION_TIME_VALUE}" == "" ]] && TOKEN_EXPIRATION_TIME_VALUE=10800  # 3 x 3600 seconds
 
+if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
+    DB_TYPE=mysql
+    DB_READY="mysqladmin ping -s --connect-timeout=3 -h $DB_HOST_NAME -P $DB_HOST_PORT"
+    DB_LIST="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'show databases'"
+    DB_USE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone'"
+fi
+
+if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
+    DB_TYPE=psql
+    READY="pg_isready -h $DB_HOST_NAME -p $DB_HOST_PORT -t 3"
+    DB_LIST="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U root -c '\l'"
+    DB_USE="PGPASSWORD=$DB_PASSWORD_VALUE psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U root -d keystone -c 'SELECT 1'"
+fi
+
 if [ "$DB_HOST_ARG" == "-dbhost" ]; then
     # Wait until DB is up, even if DB is behind a load balancer
-    while ! mysqladmin ping -s --connect-timeout=3 -h $DB_HOST_NAME -P $DB_HOST_PORT; do sleep 10; done
+    while ! eval $DB_READY; do sleep 10; done
     # Check if postlaunchconfig was executed
     chkconfig openstack-keystone --level 3
     if [ "$?" == "1" ]; then
         # Check if credentials are OK
-        mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'show databases'
+        eval $DB_LIST
         if [ "$?" == "1" ]; then
             echo "[ keystone-entrypoint - error in mysql credentials ] Keystone docker will be not configured"
             exit 1
         fi
         # Check if previos DB data exists
-        mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone'
+        eval $DB_USE
         if [ "$?" == "1" ]; then
             rm -f /var/log/keystone/keystone.log
-            /opt/keystone/postlaunchconfig.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $MYSQL_PASSWORD_ARG $MYSQL_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
+            /opt/keystone/postlaunchconfig.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $DB_PASSWORD_ARG $DB_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
         else
             rm -f /var/log/keystone/keystone.log
-            /opt/keystone/postlaunchconfig_update.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $MYSQL_PASSWORD_ARG $MYSQL_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
+            /opt/keystone/postlaunchconfig_update.sh $DB_HOST_ARG $DB_HOST_VALUE $DEFAULT_PASSWORD_ARG $DEFAULT_PASSWORD_VALUE $DB_PASSWORD_ARG $DB_PASSWORD_VALUE $TOKEN_EXPIRATION_TIME_ARG $TOKEN_EXPIRATION_TIME_VALUE
         fi
     fi
 fi

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -24,9 +24,10 @@ if [ "$DEFAULT_PASSWORD_ARG" == "-default_pwd" ]; then
     KEYSTONE_ADMIN_PASSWORD=$DEFAULT_PASSWORD_VALUE
 fi
 
+DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
+
 if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
     DB_HOST_PORT=3306
-    DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
     DB_TYPE="mysql+pymysql"
     DB_CREATE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_ROOT_PASSWORD <<EOF
 CREATE DATABASE keystone;
@@ -44,7 +45,6 @@ fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
     DB_HOST_PORT=5432
-    DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
     DB_TYPE="postgresql+psycopg2"
     DB_NAME="keystone"
     DB_USER="keystone"

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -15,14 +15,6 @@ DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
 [[ "${DB_USER}" == "" ]] && DB_USER="keystone"
 [[ "${DB_PASSWORD}" == "" ]] && DB_PASSWORD="keystone"
 
-echo "INFO: LOG LEVEL <${LOG_LEVEL}>"
-echo "INFO: DB endpoint <${DB_HOST_VALUE}>"
-echo "INFO: DB_HOST_NAME <${DB_HOST_NAME}>"
-echo "INFO: DB_HOST_PORT <${DB_HOST_PORT}>"
-echo "INFO: DB_NAME <${DB_NAME}>"
-echo "INFO: DB_USER <${DB_USER}>"
-echo "INFO: DB_PASSWORD <${DB_PASSWORD}>"
-
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
 
@@ -77,6 +69,15 @@ GRANT ALL PRIVILEGES ON DATABASE $DB_NAME TO $DB_USER;
 ALTER DATABASE $DB_NAME OWNER TO $DB_USER;
 EOF"
 fi
+
+echo "INFO: LOG LEVEL <${LOG_LEVEL}>"
+echo "INFO: DB endpoint <${DB_HOST_VALUE}>"
+echo "INFO: DB_HOST_NAME <${DB_HOST_NAME}>"
+echo "INFO: DB_HOST_PORT <${DB_HOST_PORT}>"
+echo "INFO: DB_NAME <${DB_NAME}>"
+echo "INFO: DB_USER <${DB_USER}>"
+echo "INFO: DB_PASSWORD <${DB_PASSWORD}>"
+
 
 if [ "${KEYSTONE_PEP_PASSWORD}" == "" ]; then
    KEYSTONE_PEP_PASSWORD=$KEYSTONE_ADMIN_PASSWORD

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -25,6 +25,7 @@ if [ "$DEFAULT_PASSWORD_ARG" == "-default_pwd" ]; then
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
+    DB_HOST_PORT=3306
     DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
     DB_TYPE="mysql+pymysql"
     DB_CREATE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_ROOT_PASSWORD <<EOF
@@ -42,8 +43,12 @@ EOF"
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
+    DB_HOST_PORT=5432
     DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
-    DB_TYPE="postgresql"
+    DB_TYPE="postgresql+psycopg2"
+    DB_NAME="keystone"
+    DB_USER="keystone"
+    DB_PASSWORD="keystone"
     DB_CREATE="PGPASSWORD=$DB_ROOT_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U postgres <<EOF
 CREATE DATABASE $DB_NAME;
 CREATE USER $DB_USER WITH PASSWORD '$DB_PASSWORD';

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -8,8 +8,12 @@ DB_HOST_ARG=${1}
 DB_HOST_VALUE=${2}
 DB_HOST_NAME="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $1}')"
 DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
-# Default MySQL port 3306
+# Default DB port 3306 (default is mysql)
 [[ "${DB_HOST_PORT}" == "" ]] && DB_HOST_PORT=3306
+# Default user and DB
+[[ "${DB_NAME}" == "" ]] && DB_NAME="keystone"
+[[ "${DB_USER}" == "" ]] && DB_USER="keystone"
+[[ "${DB_PASSWORD}" == "" ]] && DB_PASSWORD="keystone"
 
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
@@ -30,25 +34,22 @@ if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
     DB_HOST_PORT=3306
     DB_TYPE="mysql+pymysql"
     DB_CREATE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_ROOT_PASSWORD <<EOF
-CREATE DATABASE keystone;
-GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' IDENTIFIED BY 'keystone';
-GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%' IDENTIFIED BY 'keystone';
+CREATE DATABASE $DB_NAME;
+GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'%' IDENTIFIED BY '$DB_PASSWORD';
 EOF"
     DB_CREATE2="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_ROOT_PASSWORD <<EOF
-CREATE DATABASE IF NOT EXISTS keystone;
-CREATE USER IF NOT EXISTS 'keystone'@'localhost' IDENTIFIED BY 'keystone';
-GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost';
-CREATE USER IF NOT EXISTS 'keystone'@'%' IDENTIFIED BY 'keystone';
-GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%';
+CREATE DATABASE IF NOT EXISTS $DB_NAME;
+CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost';
+CREATE USER IF NOT EXISTS '$DB_USER'@'%' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'%';
 EOF"
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
     DB_HOST_PORT=5432
     DB_TYPE="postgresql+psycopg2"
-    DB_NAME="keystone"
-    DB_USER="keystone"
-    DB_PASSWORD="keystone"
     DB_CREATE="PGPASSWORD=$DB_ROOT_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U postgres <<EOF
 CREATE DATABASE $DB_NAME;
 CREATE USER $DB_USER WITH PASSWORD '$DB_PASSWORD';
@@ -92,7 +93,7 @@ fi
 
 if [ "$DB_HOST_ARG" == "-dbhost" ]; then
     openstack-config --set /etc/keystone/keystone.conf \
-                     database connection $DB_TYPE://keystone:keystone@$DB_HOST_NAME:$DB_HOST_PORT/keystone;
+                     database connection $DB_TYPE://$DB_USER:$DB_PASSWORD@$DB_HOST_NAME:$DB_HOST_PORT/$DB_NAME;
     # It is supposed that keystone database does not exist, it was checked by previous script
     echo "[postlaunchconfig]  $DB_CREATE"
     eval "$DB_CREATE"

--- a/docker/postlaunchconfig.sh
+++ b/docker/postlaunchconfig.sh
@@ -15,6 +15,14 @@ DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
 [[ "${DB_USER}" == "" ]] && DB_USER="keystone"
 [[ "${DB_PASSWORD}" == "" ]] && DB_PASSWORD="keystone"
 
+echo "INFO: LOG LEVEL <${LOG_LEVEL}>"
+echo "INFO: DB endpoint <${DB_HOST_VALUE}>"
+echo "INFO: DB_HOST_NAME <${DB_HOST_NAME}>"
+echo "INFO: DB_HOST_PORT <${DB_HOST_PORT}>"
+echo "INFO: DB_NAME <${DB_NAME}>"
+echo "INFO: DB_USER <${DB_USER}>"
+echo "INFO: DB_PASSWORD <${DB_PASSWORD}>"
+
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
 

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -26,22 +26,22 @@ fi
 
 if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
     DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
-    DB_ID_ADMIN_DOMAIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name=\"admin_domain\";' | awk '{if ($2==\"admin_domain\") print $1}'"
-    DB_IOTAGENT_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"iotagent\" and u.domain_id=\"default\";' | awk '{if ($4==\"iotagent\") print $2}'"
-    DB_NAGIOS_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"nagios\" and u.domain_id=\"default\";' | awk '{if ($4==\"nagios\") print $2}'"
-    DB_CEP_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cep\" and u.domain_id=\"default\";' | awk '{if ($4==\"cep\") print $2}'"
-    DB_ID_CLOUD_ADMIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cloud_admin\" and u.domain_id=\"'${ID_ADMIN_DOMAIN}'\";' | awk '{if ($4==\"cloud_admin\") print $2}'"
-    DB_ID_CLOUD_SERVICE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"pep\" and u.domain_id=\"'${ID_ADMIN_DOMAIN}'\";' | awk '{if ($4==\"pep\") print $2}'"
+    DB_ID_ADMIN_DOMAIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name=\"admin_domain\";'"
+    DB_IOTAGENT_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"iotagent\" and u.domain_id=\"default\";'"
+    DB_NAGIOS_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"nagios\" and u.domain_id=\"default\";' | awk '{if ($4==\"nagios\") print $2}'"
+    DB_CEP_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cep\" and u.domain_id=\"default\";'"
+    DB_ID_CLOUD_ADMIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cloud_admin\" and u.domain_id=\"'${ID_ADMIN_DOMAIN}'\";'"
+    DB_ID_CLOUD_SERVICE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"pep\" and u.domain_id=\"'${ID_ADMIN_DOMAIN}'\";'"
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
     DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
-    DB_ID_ADMIN_DOMAIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM project WHERE name='admin_domain';\" | awk '{if ($2==\"admin_domain\") print $1}'"
-    DB_IOTAGENT_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='iotagent' AND domain_id='default';\" | awk '{print \$1}'"
-    DB_NAGIOS_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='nagios' AND domain_id='default';\" | awk '{print \$1}'"
-    DB_CEP_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cep' AND domain_id='default';\" | awk '{print \$1}'"
-    DB_ID_CLOUD_ADMIN_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cloud_admin' AND domain_id='${ID_ADMIN_DOMAIN}';\" | awk '{print \$1}'"
-    DB_ID_CLOUD_SERVICE_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='pep' AND domain_id='${ID_ADMIN_DOMAIN}';\" | awk '{print \$1}'"
+    DB_ID_ADMIN_DOMAIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM project WHERE name='admin_domain';\""
+    DB_IOTAGENT_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='iotagent' AND domain_id='default';\" "
+    DB_NAGIOS_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='nagios' AND domain_id='default';\" "
+    DB_CEP_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cep' AND domain_id='default';\" "
+    DB_ID_CLOUD_ADMIN_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cloud_admin' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
+    DB_ID_CLOUD_SERVICE_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='pep' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
 fi
 
 [[ "${SPASSWORD_ENABLED}" == "" ]] && export SPASSWORD_ENABLED=True
@@ -145,7 +145,7 @@ sleep 5
 
 # Get Domain Admin Id form domain if Liberty or minor or project if Mitaka or uppper
 #ID_ADMIN_DOMAIN=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name="admin_domain";' | awk '{if ($2=="admin_domain") print $1}'`
-ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN")
+ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')
 echo "ID_ADMIN_DOMAIN: $ID_ADMIN_DOMAIN"
 [[ "${ID_ADMIN_DOMAIN}" == null ]] && exit 0
 [[ "${ID_ADMIN_DOMAIN}" == "" ]] && exit 0
@@ -212,11 +212,11 @@ fi
 openstack-config --set /etc/keystone/keystone.conf \
                  DEFAULT admin_token $KEYSTONE_ADMIN_PASSWORD
 
-IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID")
-NAGIOS_ID=$(eval "$DB_NAGIOS_ID")
-CEP_ID=$(eval "$DB_CEP_ID")
-ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN")
-ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE")
+IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID" | awk '{if ($4=="iotagent") print $2}')
+NAGIOS_ID=$(eval "$DB_NAGIOS_ID" | awk '{if ($4=="nagios") print $2}'
+CEP_ID=$(eval "$DB_CEP_ID" | awk '{if ($4=="cep") print $2}' )
+ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN" | awk '{if ($4=="cloud_admin") print $2}')
+ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE" | awk '{if ($4=="pep") print $2}')
 echo "IOTAGENT_ID: $IOTAGENT_ID"
 echo "NAGIOS_ID: $NAGIOS_ID"
 echo "CEP_ID: $CEP_ID"

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -15,14 +15,6 @@ DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
 [[ "${DB_USER}" == "" ]] && DB_USER="keystone"
 [[ "${DB_PASSWORD}" == "" ]] && DB_PASSWORD="keystone"
 
-echo "INFO: LOG LEVEL <${LOG_LEVEL}>"
-echo "INFO: DB endpoint <${DB_HOST_VALUE}>"
-echo "INFO: DB_HOST_NAME <${DB_HOST_NAME}>"
-echo "INFO: DB_HOST_PORT <${DB_HOST_PORT}>"
-echo "INFO: DB_NAME <${DB_NAME}>"
-echo "INFO: DB_USER <${DB_USER}>"
-echo "INFO: DB_PASSWORD <${DB_PASSWORD}>"
-
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
 
@@ -45,6 +37,14 @@ if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
     DB_TYPE="postgresql+psycopg2"
 fi
 DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
+
+echo "INFO: LOG LEVEL <${LOG_LEVEL}>"
+echo "INFO: DB endpoint <${DB_HOST_VALUE}>"
+echo "INFO: DB_HOST_NAME <${DB_HOST_NAME}>"
+echo "INFO: DB_HOST_PORT <${DB_HOST_PORT}>"
+echo "INFO: DB_NAME <${DB_NAME}>"
+echo "INFO: DB_USER <${DB_USER}>"
+echo "INFO: DB_PASSWORD <${DB_PASSWORD}>"
 
 [[ "${SPASSWORD_ENABLED}" == "" ]] && export SPASSWORD_ENABLED=True
 [[ "${SPASSWORD_PWD_MAX_TRIES}" == "" ]] && export SPASSWORD_PWD_MAX_TRIES=5

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -213,7 +213,7 @@ openstack-config --set /etc/keystone/keystone.conf \
                  DEFAULT admin_token $KEYSTONE_ADMIN_PASSWORD
 
 IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID" | awk '{if ($4=="iotagent") print $2}')
-NAGIOS_ID=$(eval "$DB_NAGIOS_ID" | awk '{if ($4=="nagios") print $2}'
+NAGIOS_ID=$(eval "$DB_NAGIOS_ID" | awk '{if ($4=="nagios") print $2}')
 CEP_ID=$(eval "$DB_CEP_ID" | awk '{if ($4=="cep") print $2}' )
 ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN" | awk '{if ($4=="cloud_admin") print $2}')
 ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE" | awk '{if ($4=="pep") print $2}')

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -8,8 +8,12 @@ DB_HOST_ARG=${1}
 DB_HOST_VALUE=${2}
 DB_HOST_NAME="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $1}')"
 DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
-# Default MySQL port 3306
+# Default DB port 3306 (default is mysql)
 [[ "${DB_HOST_PORT}" == "" ]] && DB_HOST_PORT=3306
+# Default user and DB
+[[ "${DB_NAME}" == "" ]] && DB_NAME="keystone"
+[[ "${DB_USER}" == "" ]] && DB_USER="keystone"
+[[ "${DB_PASSWORD}" == "" ]] && DB_PASSWORD="keystone"
 
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
@@ -52,7 +56,7 @@ DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
 
 if [ "$DB_HOST_ARG" == "-dbhost" ]; then
     openstack-config --set /etc/keystone/keystone.conf \
-                     database connection $DB_TYPE://keystone:keystone@$DB_HOST_NAME:$DB_HOST_PORT/keystone;
+                     database connection $DB_TYPE://$DB_USER:$DB_PASSWORD@$DB_HOST_NAME:$DB_HOST_PORT/$DB_NAME;
 
 fi
 

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -136,24 +136,36 @@ if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
     DB_ID_ADMIN_DOMAIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name=\"admin_domain\";'"
     ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')
     DB_IOTAGENT_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"iotagent\" and u.domain_id=\"default\";'"
+    IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID" | awk '{if ($4=="iotagent") print $2}')
     DB_NAGIOS_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"nagios\" and u.domain_id=\"default\";' "
+    NAGIOS_ID=$(eval "$DB_NAGIOS_ID" | awk '{if ($4=="nagios") print $2}')
     DB_CEP_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cep\" and u.domain_id=\"default\";'"
+    CEP_ID=$(eval "$DB_CEP_ID" | awk '{if ($4=="cep") print $2}' )
     DB_ID_CLOUD_ADMIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cloud_admin\" and u.domain_id=\"$ID_ADMIN_DOMAIN\";'"
+    ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN" | awk '{if ($4=="cloud_admin") print $2}')
     DB_ID_CLOUD_SERVICE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$DB_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"pep\" and u.domain_id=\"$ID_ADMIN_DOMAIN\";'"
+    ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE" | awk '{if ($4=="pep") print $2}')
 fi
 
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
+    DB_NAME="keystone"
+    DB_USER="keystone"
+    DB_PASSWORD="keystone"
     DB_ID_ADMIN_DOMAIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM project WHERE name='admin_domain';\""
-    ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')
-    DB_IOTAGENT_ID="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='iotagent' AND domain_id='default';\" "
-    DB_NAGIOS_ID="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='nagios' AND domain_id='default';\" "
-    DB_CEP_ID="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cep' AND domain_id='default';\" "
-    DB_ID_CLOUD_ADMIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cloud_admin' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
-    DB_ID_CLOUD_SERVICE="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='pep' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
+    ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($3=="admin_domain") print $1}')
+    DB_IOTAGENT_ID="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM local_user WHERE name='iotagent' AND domain_id='default';\" "
+    IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID" | awk '{if ($7=="iotagent") print $3}')
+    DB_NAGIOS_ID="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM local_user WHERE name='nagios' AND domain_id='default';\" "
+    NAGIOS_ID=$(eval "$DB_NAGIOS_ID" | awk '{if ($7=="nagios") print $3}')
+    DB_CEP_ID="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM local_user WHERE name='cep' AND domain_id='default';\" "
+    CEP_ID=$(eval "$DB_CEP_ID" | awk '{if ($7=="cep") print $3}' )
+    DB_ID_CLOUD_ADMIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM local_user WHERE name='cloud_admin' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
+    ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN" | awk '{if ($7=="cloud_admin") print $3}')
+    DB_ID_CLOUD_SERVICE="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM local_user WHERE name='pep' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
+    ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE" | awk '{if ($7=="pep") print $3}')
 fi
 
 # Get Domain Admin Id form domain if Liberty or minor or project if Mitaka or uppper
-ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')
 echo "ID_ADMIN_DOMAIN: $ID_ADMIN_DOMAIN"
 [[ "${ID_ADMIN_DOMAIN}" == null ]] && exit 0
 [[ "${ID_ADMIN_DOMAIN}" == "" ]] && exit 0
@@ -220,11 +232,6 @@ fi
 openstack-config --set /etc/keystone/keystone.conf \
                  DEFAULT admin_token $KEYSTONE_ADMIN_PASSWORD
 
-IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID" | awk '{if ($4=="iotagent") print $2}')
-NAGIOS_ID=$(eval "$DB_NAGIOS_ID" | awk '{if ($4=="nagios") print $2}')
-CEP_ID=$(eval "$DB_CEP_ID" | awk '{if ($4=="cep") print $2}' )
-ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN" | awk '{if ($4=="cloud_admin") print $2}')
-ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE" | awk '{if ($4=="pep") print $2}')
 echo "IOTAGENT_ID: $IOTAGENT_ID"
 echo "NAGIOS_ID: $NAGIOS_ID"
 echo "CEP_ID: $CEP_ID"

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -159,7 +159,7 @@ fi
 
 
 # Get Domain Admin Id form domain if Liberty or minor or project if Mitaka or uppper
-#ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')
+ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')
 echo "ID_ADMIN_DOMAIN: $ID_ADMIN_DOMAIN"
 [[ "${ID_ADMIN_DOMAIN}" == null ]] && exit 0
 [[ "${ID_ADMIN_DOMAIN}" == "" ]] && exit 0

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 KEYSTONE_ADMIN_PASSWORD=4pass1w0rd
-MYSQL_ROOT_PASSWORD="iotonpremise"
+DB_ROOT_PASSWORD="iotonpremise"
 
 DB_HOST_ARG=${1}
 # DB_HOST_VALUE can be hostname[:port]
@@ -14,8 +14,8 @@ DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
 
-MYSQL_PASSWORD_ARG=${5}
-MYSQL_PASSWORD_VALUE=${6}
+DB_PASSWORD_ARG=${5}
+DB_PASSWORD_VALUE=${6}
 
 TOKEN_EXPIRATION_TIME_ARG=${7}
 TOKEN_EXPIRATION_TIME_VALUE=${8}
@@ -24,8 +24,24 @@ if [ "$DEFAULT_PASSWORD_ARG" == "-default_pwd" ]; then
     KEYSTONE_ADMIN_PASSWORD=$DEFAULT_PASSWORD_VALUE
 fi
 
-if [ "$MYSQL_PASSWORD_ARG" == "-mysql_pwd" ]; then
-    MYSQL_ROOT_PASSWORD="$MYSQL_PASSWORD_VALUE"
+if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
+    DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
+    DB_ID_ADMIN_DOMAIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name=\"admin_domain\";' | awk '{if ($2==\"admin_domain\") print $1}'"
+    DB_IOTAGENT_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"iotagent\" and u.domain_id=\"default\";' | awk '{if ($4==\"iotagent\") print $2}'"
+    DB_NAGIOS_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"nagios\" and u.domain_id=\"default\";' | awk '{if ($4==\"nagios\") print $2}'"
+    DB_CEP_ID="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cep\" and u.domain_id=\"default\";' | awk '{if ($4==\"cep\") print $2}'"
+    DB_ID_CLOUD_ADMIN="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"cloud_admin\" and u.domain_id=\"'${ID_ADMIN_DOMAIN}'\";' | awk '{if ($4==\"cloud_admin\") print $2}'"
+    DB_ID_CLOUD_SERVICE="mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name=\"pep\" and u.domain_id=\"'${ID_ADMIN_DOMAIN}'\";' | awk '{if ($4==\"pep\") print $2}'"
+fi
+
+if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
+    DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
+    DB_ID_ADMIN_DOMAIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT * FROM project WHERE name='admin_domain';\" | awk '{if ($2==\"admin_domain\") print $1}'"
+    DB_IOTAGENT_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='iotagent' AND domain_id='default';\" | awk '{print \$1}'"
+    DB_NAGIOS_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='nagios' AND domain_id='default';\" | awk '{print \$1}'"
+    DB_CEP_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cep' AND domain_id='default';\" | awk '{print \$1}'"
+    DB_ID_CLOUD_ADMIN_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cloud_admin' AND domain_id='${ID_ADMIN_DOMAIN}';\" | awk '{print \$1}'"
+    DB_ID_CLOUD_SERVICE_CMD="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='pep' AND domain_id='${ID_ADMIN_DOMAIN}';\" | awk '{print \$1}'"
 fi
 
 [[ "${SPASSWORD_ENABLED}" == "" ]] && export SPASSWORD_ENABLED=True
@@ -128,7 +144,8 @@ sleep 5
 
 
 # Get Domain Admin Id form domain if Liberty or minor or project if Mitaka or uppper
-ID_ADMIN_DOMAIN=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name="admin_domain";' | awk '{if ($2=="admin_domain") print $1}'`
+#ID_ADMIN_DOMAIN=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from project p where p.name="admin_domain";' | awk '{if ($2=="admin_domain") print $1}'`
+ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN")
 echo "ID_ADMIN_DOMAIN: $ID_ADMIN_DOMAIN"
 [[ "${ID_ADMIN_DOMAIN}" == null ]] && exit 0
 [[ "${ID_ADMIN_DOMAIN}" == "" ]] && exit 0
@@ -195,13 +212,11 @@ fi
 openstack-config --set /etc/keystone/keystone.conf \
                  DEFAULT admin_token $KEYSTONE_ADMIN_PASSWORD
 
-
-
-IOTAGENT_ID=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name="iotagent" and u.domain_id="default";' | awk '{if ($4=="iotagent") print $2}'`
-NAGIOS_ID=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name="nagios" and u.domain_id="default";' | awk '{if ($4=="nagios") print $2}'`
-CEP_ID=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name="cep" and u.domain_id="default";' | awk '{if ($4=="cep") print $2}'`
-ID_CLOUD_ADMIN=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name="cloud_admin" and u.domain_id="'${ID_ADMIN_DOMAIN}'";' | awk '{if ($4=="cloud_admin") print $2}'`
-ID_CLOUD_SERVICE=`mysql -h $DB_HOST_NAME --port $DB_HOST_PORT -u root --password=$MYSQL_PASSWORD_VALUE -e 'use keystone; select * from local_user u where u.name="pep" and u.domain_id="'${ID_ADMIN_DOMAIN}'";' | awk '{if ($4=="pep") print $2}'`
+IOTAGENT_ID=$(eval "$DB_IOTAGENT_ID")
+NAGIOS_ID=$(eval "$DB_NAGIOS_ID")
+CEP_ID=$(eval "$DB_CEP_ID")
+ID_CLOUD_ADMIN=$(eval "$DB_ID_CLOUD_ADMIN")
+ID_CLOUD_SERVICE=$(eval "$DB_ID_CLOUD_SERVICE")
 echo "IOTAGENT_ID: $IOTAGENT_ID"
 echo "NAGIOS_ID: $NAGIOS_ID"
 echo "CEP_ID: $CEP_ID"

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -15,6 +15,14 @@ DB_HOST_PORT="$(echo "${DB_HOST_VALUE}" | awk -F: '{print $2}')"
 [[ "${DB_USER}" == "" ]] && DB_USER="keystone"
 [[ "${DB_PASSWORD}" == "" ]] && DB_PASSWORD="keystone"
 
+echo "INFO: LOG LEVEL <${LOG_LEVEL}>"
+echo "INFO: DB endpoint <${DB_HOST_VALUE}>"
+echo "INFO: DB_HOST_NAME <${DB_HOST_NAME}>"
+echo "INFO: DB_HOST_PORT <${DB_HOST_PORT}>"
+echo "INFO: DB_NAME <${DB_NAME}>"
+echo "INFO: DB_USER <${DB_USER}>"
+echo "INFO: DB_PASSWORD <${DB_PASSWORD}>"
+
 DEFAULT_PASSWORD_ARG=${3}
 DEFAULT_PASSWORD_VALUE=${4}
 

--- a/docker/postlaunchconfig_update.sh
+++ b/docker/postlaunchconfig_update.sh
@@ -30,7 +30,7 @@ if [ "$DB_PASSWORD_ARG" == "-mysql_pwd" ]; then
 fi
 if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
     DB_HOST_PORT=5432
-    DB_TYPE="postgresql"
+    DB_TYPE="postgresql+psycopg2"
 fi
 DB_ROOT_PASSWORD="$DB_PASSWORD_VALUE"
 
@@ -151,12 +151,6 @@ if [ "$DB_PASSWORD_ARG" == "-psql_pwd" ]; then
     DB_ID_CLOUD_ADMIN="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='cloud_admin' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
     DB_ID_CLOUD_SERVICE="PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST_NAME -p $DB_HOST_PORT -U $DB_USER -d $DB_NAME -t -c \"SELECT id FROM local_user WHERE name='pep' AND domain_id='${ID_ADMIN_DOMAIN}';\" "
 fi
-
-
-
-
-
-
 
 # Get Domain Admin Id form domain if Liberty or minor or project if Mitaka or uppper
 ID_ADMIN_DOMAIN=$(eval "$DB_ID_ADMIN_DOMAIN" | awk '{if ($2=="admin_domain") print $1}')

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -24,6 +24,11 @@ The following environment variables are available for keystone-spassword docker
 | SAML_ENDPOINT               | Keystone Endpoint used to expose SAML API for idp and sso options  | N/A            |
 | SAML_CERTFILE               | File location for SSL signing certificate (certfile)    | N/A            |
 | SAML_KEYFILE                | File location for SSL signing key (keyfile)             | N/A            |
+| DB_NAME                     | DB name                                                 | keystone       |
+| DB_USER                     | DB user name                                            | keystone       |
+| DB_PASSWORD                 | DB user password                                        | keystone       |
+
+
 
 Orchestrator also needs some command line options for start using docker:
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -25,3 +25,12 @@ The following environment variables are available for keystone-spassword docker
 | SAML_CERTFILE               | File location for SSL signing certificate (certfile)    | N/A            |
 | SAML_KEYFILE                | File location for SSL signing key (keyfile)             | N/A            |
 
+Orchestrator also needs some command line options for start using docker:
+
+
+| Command parameter | Description                                |
+|:------------------|:-------------------------------------------|
+| -dbhost           | Host/IP database                           |
+| -mysql_pwd        | Default database password when MySQL       |
+| -psql_pwd         | Default database password when PostgreSQL  |
+| -default_pwd      | Default password used by special users     |

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -33,4 +33,4 @@ Orchestrator also needs some command line options for start using docker:
 | -dbhost           | Host/IP database                           |
 | -mysql_pwd        | Default database password when MySQL       |
 | -psql_pwd         | Default database password when PostgreSQL  |
-| -default_pwd      | Default password used by special users     |
+| -default_pwd      | Default password used to provision of special users     |


### PR DESCRIPTION
https://github.com/telefonicaid/fiware-keystone-spassword/issues/256
instead of use ``` -mysql_pwd ``` to enable PostgreSQL should be ```-psql_pwd```

- [x] Tested bootstrap from 0 in postgis 12
- [x] Tested bootstrap from 0 in postgis 13.19
